### PR TITLE
🔒 Replace hardcoded gateway token with environment variable

### DIFF
--- a/infrastructure/assets/openclaw.json
+++ b/infrastructure/assets/openclaw.json
@@ -160,7 +160,7 @@
     },
     "auth": {
       "mode": "token",
-      "token": "8156ecdc6d750aa7d55e3b73e40b68ceb33386adfed8da76",
+      "token": "${OPENCLAW_GATEWAY_AUTH_TOKEN}",
       "password": "nirmal"
     },
     "trustedProxies": [


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The authentication token for the OpenClaw gateway was explicitly hardcoded in the `infrastructure/assets/openclaw.json` configuration file.

⚠️ **Risk:** The potential impact if left unfixed
Hardcoded credentials in source code can be easily discovered, leading to unauthorized access to the OpenClaw gateway. This could allow an attacker to control the AI agents and potentially access sensitive data or perform actions on the user's behalf.

🛡️ **Solution:** How the fix addresses the vulnerability
The hardcoded token has been replaced with a reference to an environment variable (`${OPENCLAW_GATEWAY_AUTH_TOKEN}`). This allows the token to be provided at runtime, keeping the actual secret out of the codebase. The Ansible deployment script already handles populating this environment variable.

---
*PR created automatically by Jules for task [10959851739327863725](https://jules.google.com/task/10959851739327863725) started by @nirmalhk7*